### PR TITLE
Fix typo in bug-reports and build-depends.

### DIFF
--- a/cabal-edit.cabal
+++ b/cabal-edit.cabal
@@ -6,7 +6,7 @@ license-file:       LICENSE
 copyright:          2020 Stephen Diehl
 maintainer:         stephen.m.diehl@gmail.com
 author:             sdiehl
-bug-reports:        https:/www.github.com/sdiehl/cabal-add/issues
+bug-reports:        https://www.github.com/sdiehl/cabal-edit/issues
 synopsis:           Cabal utility
 description:
   A utility for managing Hackage dependencies from the command line.
@@ -27,9 +27,9 @@ executable cabal-edit
   default-language: Haskell2010
   ghc-options:      -Wall
   build-depends:
-    , base                  >=4.12 && <5.0
+    , base                  >=4.12 && <5
     , bytestring            ^>=0.10
-    , Cabal                 >=3.0  && <4.0
+    , Cabal                 >=3.0  && <4
     , containers            ^>=0.6
     , directory             ^>=1.3
     , filepath              ^>=1.4


### PR DESCRIPTION
About `build-depends` change: `5 < 5.0` as far as version numbers are considered.

Also using `<4` for `Cabal` is just waiting for problems to happen, It's very likely your package will break every six or so months, when new major `Cabal` versions are released. (`GenericPackageDescription` types do change, e.g. `Dependency` will change in `3.4`).